### PR TITLE
Truffle 3.x Migration

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,3 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(Migrations);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,4 +1,8 @@
+var SmartIdentity = artifacts.require("SmartIdentity.sol");
+var SmartIdentityRegistry = artifacts.require("SmartIdentityRegistry.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(SmartIdentity);
-  deployer.autolink();
+  deployer.deploy(SmartIdentityRegistry);
+  deployer.link(SmartIdentity, SmartIdentityRegistry);
 };

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "ethereumjs-testrpc": "^3.0.0",
-    "truffle": "^2.1.0"
+    "truffle": "^2.1.0",
+    "truffle-default-builder": "^2.0.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "scripts": {
     "test": "./node_modules/.bin/truffle test"
   },

--- a/test/functional/SmartIdentity/attributetest.js
+++ b/test/functional/SmartIdentity/attributetest.js
@@ -44,7 +44,7 @@ contract('SmartIdentity', function(accounts) {
             return smartIdentity.addAttribute(attributeHash1, {from: owner})
             .then(function(response) {
                 assert.isOk(response, "Attribute addition failed");
-                var addAttributeStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var addAttributeStatus = response.logs[0].args.status;
                 assert.equal(4, addAttributeStatus, "Transaction returned unexpected status");
             });
         });
@@ -161,7 +161,7 @@ contract('SmartIdentity', function(accounts) {
         it("will remove an attribute as an owner, and succeed", function() {
             return smartIdentity.removeAttribute(attributeHash1, {from: owner})
             .then(function(response) {
-                var removeAttributeStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var removeAttributeStatus = response.logs[0].args.status;
                 assert.equal(3, removeAttributeStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute removal failed");
             });
@@ -175,9 +175,9 @@ contract('SmartIdentity', function(accounts) {
         });
 
         it("will add a new attribute as the owner, and succeed", function() {
-            smartIdentity.addAttribute(attributeHash4, {from: owner})
+            return smartIdentity.addAttribute(attributeHash4, {from: owner})
             .then(function(response) {
-                var addAttributeStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var addAttributeStatus = response.logs[0].args.status;
                 assert.equal(4, addAttributeStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute addition failed");
             });
@@ -195,10 +195,10 @@ contract('SmartIdentity', function(accounts) {
             var newAttributeHash = "0x154f7ce000000000000000000000000000000000000000000000000000000000";
             return smartIdentity.updateAttribute(oldAttributeHash, newAttributeHash, {from: owner})
             .then(function(response) {
-                var debugStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
-                var removeAttributeStatus = web3.eth.getTransactionReceipt(response).logs[1].data[65];
-                var addAttributeStatus = web3.eth.getTransactionReceipt(response).logs[2].data[65];
-                var updateAttributeStatus = web3.eth.getTransactionReceipt(response).logs[3].data[65];
+                var debugStatus = response.logs[0].args.status;
+                var removeAttributeStatus = response.logs[1].args.status;
+                var addAttributeStatus = response.logs[2].args.status;
+                var updateAttributeStatus = response.logs[3].args.status;
                 assert.equal(5, debugStatus, "Transaction returned unexpected status");
                 assert.equal(3, removeAttributeStatus, "Transaction returned unexpected status");
                 assert.equal(4, addAttributeStatus, "Transaction returned unexpected status");

--- a/test/functional/SmartIdentity/attributetest.js
+++ b/test/functional/SmartIdentity/attributetest.js
@@ -3,6 +3,8 @@
   * that use attributes.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/blocklocktest.js
+++ b/test/functional/SmartIdentity/blocklocktest.js
@@ -29,34 +29,29 @@ contract('SmartIdentity', function(accounts) {
 
     describe("Blocklock tests", function() {
 
-        it("will create a new user and immediately set a new owner successfully", function(done) {
-            SmartIdentity.new({from: owner})
-            .then(function(identity) {
-                identity.setOwner(thirdparty, {from: override})
-                .then(function(response) {
-                    var newOwnerStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
-                    assert.equal(3, newOwnerStatus, "Transaction returned unexpected status");
-                    assert.isOk(response, "Setting new owner failed");
-                    done();
-                });
-            });
-        });
-
-        it("will set thirdparty as the new owner by an override user", function(done) {
-            smartIdentity.setOwner(thirdparty, {from: override})
-            .then(function(response) {
-                var newOwnerStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+        it("will create a new user and immediately set a new owner successfully", function() {
+            return SmartIdentity.new({from: owner}).then(function(identity) {
+                return identity.setOwner(thirdparty, {from: override})
+            }).then(function(response) {
+                var newOwnerStatus = response.logs[0].args.status;
                 assert.equal(3, newOwnerStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Setting new owner failed");
-                done();
             });
         });
 
-        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function(done) {
-            smartIdentity.setOwner(thirdparty, {from: override})
-            .catch(function(error) {
+        it("will set thirdparty as the new owner by an override user", function() {
+            return smartIdentity.setOwner(thirdparty, {from: override}).then(function(response) {
+                var newOwnerStatus = response.logs[0].args.status;
+                assert.equal(3, newOwnerStatus, "Transaction returned unexpected status");
+                assert.isOk(response, "Setting new owner failed");
+            });
+        });
+
+        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function() {
+            return smartIdentity.setOwner(thirdparty, {from: override}).then(function(){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
@@ -67,21 +62,18 @@ contract('SmartIdentity', function(accounts) {
             });
         }
 
-        it("will set the override to a thirdparty owner", function(done) {
-            smartIdentity.setOverride(accounts[3], {from: thirdparty})
-            .then(function(response) {
-                var newOverrideStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+        it("will set the override to a thirdparty owner", function() {
+            return smartIdentity.setOverride(accounts[3], {from: thirdparty}).then(function(response) {
+                var newOverrideStatus = response.logs[0].args.status;
                 assert.equal(3, newOverrideStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Setting override failed");
-                done();
             });
         });
 
-        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function(done) {
+        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function() {
             smartIdentity.setOwner(thirdparty, {from: override})
             .catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
@@ -95,7 +87,7 @@ contract('SmartIdentity', function(accounts) {
         it("will set the new owner back to 'owner' as the new override user", function(done) {
             smartIdentity.setOwner(owner, {from: accounts[3]})
             .then(function(response) {
-                var newOwnerStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var newOwnerStatus = response.logs[0].args.status;
                 assert.equal(3, newOwnerStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Setting new owner failed");
                 done();

--- a/test/functional/SmartIdentity/blocklocktest.js
+++ b/test/functional/SmartIdentity/blocklocktest.js
@@ -3,6 +3,8 @@
   * SmartIdentity.sol.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/contracttest.js
+++ b/test/functional/SmartIdentity/contracttest.js
@@ -3,6 +3,8 @@
   * that involve altering the ownership of the contract.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/contracttest.js
+++ b/test/functional/SmartIdentity/contracttest.js
@@ -34,88 +34,77 @@ contract('SmartIdentity', function(accounts) {
           * test implies that if the owner is successfully returned, the override account
           * has been correctly set.
           */
-        it("will have an owner with an override account that matches the creator of the contract", function(done) {
-            SmartIdentity.new({from: override})
-            .then(function(identity) {
-                identity.getOwner.call()
-                .then(function(response) {
-                    assert.equal(response.valueOf(), owner, "owner does not match override");
-                    done();
-                });
+        it("will have an owner with an override account that matches the creator of the contract", function() {
+            return SmartIdentity.new({from: override}).then(function(identity) {
+                return identity.getOwner.call()
+            }).then(function(response) {
+                assert.equal(response.valueOf(), owner, "owner does not match override");
             });
         });
 
-        it("will not allow a non-owner to execute the getOwner function", function(done) {
-            SmartIdentity.new({from: thirdparty})
-            .then(function(identity) {
-                identity.getOwner.call()
-                .catch(function(error) {
-                    assert.isOk(error, "Expected error has been caught");
-                    done();
-                });
+        it("will not allow a non-owner to execute the getOwner function", function() {
+            return SmartIdentity.new({from: thirdparty}).then(function(identity) {
+                return identity.getOwner.call();
+            }).then(function(error){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
+                assert.isOk(error, "Expected error has been caught");
             });
         });
 
-        it("will attempt to setOwner as a thirdparty user and fail", function(done) {
-            smartIdentity.setOwner(thirdparty, {from: thirdparty})
-            .catch(function(error) {
+        it("will attempt to setOwner as a thirdparty user and fail", function() {
+            return smartIdentity.setOwner(thirdparty, {from: thirdparty}).then(function(error){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
-        it("will attempt to setOverride as a thirdparty user and fail", function(done) {
-            smartIdentity.setOverride(thirdparty, {from: thirdparty})
-            .catch(function(error) {
+        it("will attempt to setOverride as a thirdparty user and fail", function() {
+            return smartIdentity.setOverride(thirdparty, {from: thirdparty}).then(function(error){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
-        it("will set thirdparty as the new owner by an override user (override is the owner)", function(done) {
-            smartIdentity.setOwner(thirdparty, {from: override})
-            .then(function(response) {
-                var newOwnerStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+        it("will set thirdparty as the new owner by an override user (override is the owner)", function() {
+            return smartIdentity.setOwner(thirdparty, {from: override}).then(function(response) {
+                var newOwnerStatus = response.logs[0].args.status;
                 assert.equal(3, newOwnerStatus, "Transaction returned unexpected status");
                 assert.isOk(response, 'Error produced by setOwner function');
-                done();
             });
         });
 
-        it("will verify that thirdparty is now the contract owner", function(done) {
-            smartIdentity.getOwner.call()
-            .then(function(response) {
+        it("will verify that thirdparty is now the contract owner", function() {
+            return smartIdentity.getOwner.call().then(function(response) {
                 assert.equal(response.valueOf(), thirdparty, "thirdparty is not the owner");
-                done();
             });
         });
 
-        it("will attempt to setOwner back to owner as the thirdparty user and fail as thirdparty is not override user", function(done) {
-            smartIdentity.setOwner(owner, {from: thirdparty})
-            .catch(function(error) {
+        it("will attempt to setOwner back to owner as the thirdparty user and fail as thirdparty is not override user", function() {
+            return smartIdentity.setOwner(owner, {from: thirdparty}).then(function(error){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
-        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function(done) {
-            smartIdentity.setOwner(thirdparty, {from: override})
-            .catch(function(error) {
+        it("will invoke the blocklock function when repeatedly setting a new owner as an override user", function() {
+            return smartIdentity.setOwner(thirdparty, {from: override}).then(function(){
+                assert.isOk(error, "Expected error has not been thrown");
+            }).catch(function(error) {
                 assert.isOk(error, "Expected error has not been caught");
-                done();
             });
         });
 
-        it("will create a new contract then set override to a thirdparty user", function(done) {
-            SmartIdentity.new({from: owner})
-            .then(function(identity) {
-                identity.setOverride(thirdparty, {from: override})
-                .then(function(response) {
-                    var newOverrideStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
-                    assert.equal(3, newOverrideStatus, "Transaction returned unexpected status");
-                    assert.isOk(response, "Expected error has not been caught");
-                    done();
-                });
+        it("will create a new contract then set override to a thirdparty user", function() {
+            return SmartIdentity.new({from: owner}).then(function(identity) {
+                return identity.setOverride(thirdparty, {from: override})
+            }).then(function(response) {
+                var newOverrideStatus = response.logs[0].args.status;
+                assert.equal(3, newOverrideStatus, "Transaction returned unexpected status");
+                assert.isOk(response, "Expected error has not been caught");
             });
         });
 
@@ -123,10 +112,9 @@ contract('SmartIdentity', function(accounts) {
           * Since 0.4.4, it may be preferable to change the contract to have a disabled
           * state, that also allows for the 'identity' to be migrated to a new address.
           */
-        it("will kill the contract as the owner", function(done) {
-            smartIdentity.kill({from: thirdparty}).then(function() {
+        it("will kill the contract as the owner", function() {
+            return smartIdentity.kill({from: thirdparty}).then(function() {
                 assert.equal(0, web3.eth.getBalance(smartIdentity.address).valueOf(), "Hmm, money still abounds.");
-                done();
             });
         });
     });

--- a/test/functional/SmartIdentity/encryptionKey.js
+++ b/test/functional/SmartIdentity/encryptionKey.js
@@ -3,6 +3,8 @@
   * that alter the encryption public key.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/encryptionKey.js
+++ b/test/functional/SmartIdentity/encryptionKey.js
@@ -36,7 +36,7 @@ contract('SmartIdentity', function(accounts) {
         it("will set encryption public key as the owner", function() {
             return smartIdentity.setEncryptionPublicKey(publicEncryptionKey, {from: owner})
             .then(function(response) {
-                var newEncryptKeyStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var newEncryptKeyStatus = response.logs[0].args.status;
                 assert.equal(3, newEncryptKeyStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute addition failed");
             });
@@ -52,7 +52,7 @@ contract('SmartIdentity', function(accounts) {
         it("will update the encryption public key as the owner", function() {
             return smartIdentity.setEncryptionPublicKey(newPublicEncryptionKey, {from: owner})
             .then(function(response) {
-                var newEncryptKeyStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var newEncryptKeyStatus = response.logs[0].args.status;
                 assert.equal(3, newEncryptKeyStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute addition failed");
             });

--- a/test/functional/SmartIdentity/endorsementtest.js
+++ b/test/functional/SmartIdentity/endorsementtest.js
@@ -3,6 +3,8 @@
   * that use endorsements.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/endorsementtest.js
+++ b/test/functional/SmartIdentity/endorsementtest.js
@@ -45,7 +45,7 @@ contract('SmartIdentity', function(accounts) {
             return smartIdentity.addAttribute(attributeHash1, {from: owner})
             .then(function(response) {
                 assert.isOk(response, "Attribute addition failed");
-                var addAttributeStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var addAttributeStatus = response.logs[0].args.status;
                 assert.equal(4, addAttributeStatus, "Transaction returned unexpected status");
             });
         });
@@ -60,7 +60,7 @@ contract('SmartIdentity', function(accounts) {
         it("will add an endorsement from an endorser", function() {
             return smartIdentity.addEndorsement(attributeHash1, endorsementHash, {from: endorser})
             .then(function(response) {
-                var addEndorsementStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var addEndorsementStatus = response.logs[0].args.status;
                 assert.equal(4, addEndorsementStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Endorsement addition failed");
             });
@@ -69,7 +69,7 @@ contract('SmartIdentity', function(accounts) {
         it("will accept the endorsement as the owner", function() {
             return smartIdentity.acceptEndorsement(attributeHash1, endorsementHash, {from: owner})
             .then(function(response) {
-                var acceptEndorsementStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var acceptEndorsementStatus = response.logs[0].args.status;
                 assert.equal(3, acceptEndorsementStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Endorsement was not accepted");
             });
@@ -106,7 +106,7 @@ contract('SmartIdentity', function(accounts) {
         it("will remove the endorsement as the endorser", function() {
             return smartIdentity.removeEndorsement(attributeHash1, endorsementHash, {from: endorser})
             .then(function(response) {
-                var removeEndorsementStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var removeEndorsementStatus = response.logs[0].args.status;
                 assert.equal(3, removeEndorsementStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Endorsement was not accepted");
             });
@@ -119,48 +119,40 @@ contract('SmartIdentity', function(accounts) {
             });
         });
 
-        it("will confirm that an endorsement is invalid if an attribute is removed", function(done) {
-            smartIdentity.addAttribute(attributeHash2, {from: owner})
+        it("will confirm that an endorsement is invalid if an attribute is removed", function() {
+            return smartIdentity.addAttribute(attributeHash2, {from: owner})
             .then(function(response) {
                 assert.isOk(response, "Attribute was not added successfully");
-                smartIdentity.addEndorsement(attributeHash2, endorsementHash, {from: endorser})
-                .then(function(response) {
-                    assert.isOk(response, "Endorsement was not added successfully");
-                    smartIdentity.removeAttribute(attributeHash2, {from: owner})
-                    .then(function() {
-                        assert.isOk(response, "Attribute was not removed successfully");
-                        smartIdentity.checkEndorsementExists.call(attributeHash2, endorsementHash, {from: endorser})
-                        .then(function(response) {
-                            assert.equal(response, false, "Endorsement still exists");
-                            done();
-                        });
-                    });
-                });
+                return smartIdentity.addEndorsement(attributeHash2, endorsementHash, {from: endorser})
+            }).then(function(response) {
+                assert.isOk(response, "Endorsement was not added successfully");
+                return smartIdentity.removeAttribute(attributeHash2, {from: owner})
+            }).then(function(response) {
+                assert.isOk(response, "Attribute was not removed successfully");
+                return smartIdentity.checkEndorsementExists.call(attributeHash2, endorsementHash, {from: endorser})
+            }).then(function(response) {
+                assert.equal(response, false, "Endorsement still exists");
             });
         });
 
-        it("will make sure that an endorser can delete an endorsement after an attribute has been removed", function(done) {
-            smartIdentity.addAttribute(web3.sha3("testhash"), {from: owner})
+        it("will make sure that an endorser can delete an endorsement after an attribute has been removed", function() {
+            return smartIdentity.addAttribute(web3.sha3("testhash"), {from: owner})
             .then(function(response) {
                 assert.isOk(response, "Attribute was not added successfully");
-                smartIdentity.addEndorsement(web3.sha3("testhash"), web3.sha3("testendorsement"), {from: endorser})
-                .then(function(response) {
-                    assert.isOk(response, "Endorsement was not added successfully");
-                    smartIdentity.removeAttribute(web3.sha3("testhash"), {from: owner})
-                    .then(function(response) {
-                        assert.isOk(response, "Attribute was not removed successfully");
-                        smartIdentity.removeEndorsement(web3.sha3("testhash"), web3.sha3("testendorsement"), {from: endorser})
-                        .then(function(response) {
-                            assert.isOk(response, "Endorsement not removed successfully");
-                            done();
-                        });
-                    });
-                });
+                return smartIdentity.addEndorsement(web3.sha3("testhash"), web3.sha3("testendorsement"), {from: endorser})
+            }).then(function(response) {
+                assert.isOk(response, "Endorsement was not added successfully");
+                return smartIdentity.removeAttribute(web3.sha3("testhash"), {from: owner})
+            }).then(function(response) {
+                assert.isOk(response, "Attribute was not removed successfully");
+                return smartIdentity.removeEndorsement(web3.sha3("testhash"), web3.sha3("testendorsement"), {from: endorser})
+            }).then(function(response) {
+                assert.isOk(response, "Endorsement not removed successfully");
             });
         });
 
         it("will make sure that an endorser cannot add an endorsement to a non-existent attribute", function() {
-            smartIdentity.addEndorsement(web3.sha3("non-existent attribute"), web3.sha3("new endorsement"), {from: endorser})
+            return smartIdentity.addEndorsement(web3.sha3("non-existent attribute"), web3.sha3("new endorsement"), {from: endorser})
             .catch(function(error) {
                 assert.isOk(error, "Endorsement was added for a non-existent attribute");
             });
@@ -169,7 +161,7 @@ contract('SmartIdentity', function(accounts) {
         it("will add an endorsement from the endorser for testing purposes", function() {
             return smartIdentity.addEndorsement(attributeHash1, endorsementHash2, {from: endorser})
             .then(function(response) {
-                var addEndorsementStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var addEndorsementStatus = response.logs[0].args.status;
                 assert.equal(4, addEndorsementStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Endorsement was not added");
             });
@@ -178,7 +170,7 @@ contract('SmartIdentity', function(accounts) {
         it("will remove the endorsement as the owner", function() {
             return smartIdentity.removeEndorsement(attributeHash1, endorsementHash2, {from: owner})
             .then(function(response) {
-                var removeEndorsementStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var removeEndorsementStatus = response.logs[0].args.status;
                 assert.equal(3, removeEndorsementStatus, "Transaction returned unexpected status");
                 assert.isOk(response, 'Endorsement not removed');
             });

--- a/test/functional/SmartIdentity/signingKey.js
+++ b/test/functional/SmartIdentity/signingKey.js
@@ -3,6 +3,8 @@
   * that alter the signing public key.
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var smartIdentity,

--- a/test/functional/SmartIdentity/signingKey.js
+++ b/test/functional/SmartIdentity/signingKey.js
@@ -36,7 +36,7 @@ contract('SmartIdentity', function(accounts) {
         it("will set signing public key as the owner", function() {
             return smartIdentity.setSigningPublicKey(publicSigningKey, {from: owner})
             .then(function(response) {
-                var newSigningKeyStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var newSigningKeyStatus = response.logs[0].args.status;
                 assert.equal(3, newSigningKeyStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute addition failed");
             });
@@ -52,7 +52,7 @@ contract('SmartIdentity', function(accounts) {
         it("will update the signing public key as the owner", function() {
             return smartIdentity.setSigningPublicKey(newPublicSigningKey, {from: owner})
             .then(function(response) {
-                var newSigningKeyStatus = web3.eth.getTransactionReceipt(response).logs[0].data[65];
+                var newSigningKeyStatus = response.logs[0].args.status;
                 assert.equal(3, newSigningKeyStatus, "Transaction returned unexpected status");
                 assert.isOk(response, "Attribute addition failed");
             });

--- a/test/functional/SmartIdentityRegistry/sicontracttest.js
+++ b/test/functional/SmartIdentityRegistry/sicontracttest.js
@@ -2,6 +2,8 @@
   * The purpose of this test contract is to test the functions in SmartIdentityRegistry.sol.
   */
 
+var SmartIdentityRegistry = artifacts.require("SmartIdentityRegistry");
+
 contract('SmartIdentityRegistry', function(accounts) {
 
     var registry,

--- a/test/scenarios/alice.js
+++ b/test/scenarios/alice.js
@@ -7,6 +7,8 @@
  *
  */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var alice = {},

--- a/test/scenarios/alice.js
+++ b/test/scenarios/alice.js
@@ -35,23 +35,22 @@ contract('SmartIdentity', function(accounts) {
 
     describe("Scenario: Alice has a current account with her bank, but wants to open an account for her business.", function() {
 
-        it("Should create an identity for Alice so that she can create KYC attributes", function(done) {
+        it("Should create an identity for Alice so that she can create KYC attributes", function() {
+            var encryptionKey = "test encryption key";
             return SmartIdentity.new({from: alice.address})
             .then(function(data) {
                 alice.identity = data.address;
                 assert.isOk(data, "Alice's Identity failed to be created");
 
-                var encryptionKey = "test encryption key";
-
-                data.setEncryptionPublicKey(encryptionKey, {from: alice.address})
-                .then(function() {
-                    SmartIdentity.at(alice.identity).encryptionPublicKey.call()
-                    .then(function(returnedEncryptionKey) {
+                return data.setEncryptionPublicKey(encryptionKey, {from: alice.address})
+            }).then(function() {
+                    SmartIdentity.at(alice.identity).then(function(identity){
+                      return identity.encryptionPublicKey.call();
+                    }).then(function(returnedEncryptionKey) {
                         assert.equal(encryptionKey, returnedEncryptionKey, "failed to add key");
                     });
-                }).then(done).catch(done);
+                });
             });
-        });
 
         it("Should create an identity for Alice's Retail Bank so they can endorse her KYC checks", function() {
             return SmartIdentity.new({from: retailBank.address})

--- a/test/scenarios/bob.js
+++ b/test/scenarios/bob.js
@@ -7,6 +7,8 @@
   *
   */
 
+var SmartIdentity = artifacts.require("SmartIdentity");
+
 contract('SmartIdentity', function(accounts) {
 
     var bob = {},

--- a/test/scenarios/bob.js
+++ b/test/scenarios/bob.js
@@ -35,22 +35,21 @@ contract('SmartIdentity', function(accounts) {
 
     describe("Scenario: Bob has a current account with his bank, but needs to supply additional information to apply for a mortgage.", function() {
 
-        it("Should create an identity for Bob so that he can create employement status attributes", function(done) {
+        it("Should create an identity for Bob so that he can create employement status attributes", function() {
+          var encryptionKey = "test encryption key";
+
             return SmartIdentity.new({from: bob.address})
             .then(function(data) {
                 bob.identity = data.address;
                 assert.isOk(data, "Bob's Identity failed to be created");
-
-                var encryptionKey = "test encryption key";
-
-                data.setEncryptionPublicKey(encryptionKey, {from: bob.address})
-                .then(function() {
-                    SmartIdentity.at(bob.identity).encryptionPublicKey.call()
-                    .then(function(returnedEncryptionKey) {
-                        assert.equal(encryptionKey, returnedEncryptionKey, "failed to add key");
-                    });
-                }).then(done).catch(done);
-            });
+                return data.setEncryptionPublicKey(encryptionKey, {from: bob.address})
+            }).then(function() {
+                SmartIdentity.at(bob.identity).then(function(identity){
+                    return identity.encryptionPublicKey.call();
+                }).then(function(returnedEncryptionKey) {
+                    assert.equal(encryptionKey, returnedEncryptionKey, "failed to add key");
+                })
+            })
         });
 
         it("Should create an identity for Bob's Employer so they can endorse his employment status", function() {

--- a/truffle.js
+++ b/truffle.js
@@ -11,10 +11,6 @@ module.exports = {
     ],
     "images/": "images/"
   }),
-  rpc: {
-    host: "localhost",
-    port: 8545
-  },
   networks: {
     development: {
       host: "localhost",

--- a/truffle.js
+++ b/truffle.js
@@ -1,5 +1,7 @@
+var DefaultBuilder = require("truffle-default-builder");
+
 module.exports = {
-  build: {
+  build: new DefaultBuilder({
     "index.html": "index.html",
     "app.js": [
       "javascripts/app.js"
@@ -8,9 +10,16 @@ module.exports = {
       "stylesheets/app.css"
     ],
     "images/": "images/"
-  },
+  }),
   rpc: {
     host: "localhost",
     port: 8545
+  },
+  networks: {
+    development: {
+      host: "localhost",
+      port: 8545,
+      network_id: "*" // Match any network id
+    }
   }
 };


### PR DESCRIPTION
This PR migrates from Truffle 2.x to Truffle 3.x. 
- Deployment scripts 1_initial_migration.js and 2_deploy_contracts.js updated
- Added truffle-default-builder (this simulates Truffle 2.x build behaviour, but will be deprecated in Truffle 4.x)
- Updated tests to use Promises and 3.x event syntax, all passing