### PR TITLE
Replaced all throw with revert()

### DIFF
--- a/contracts/SmartIdentity.sol
+++ b/contracts/SmartIdentity.sol
@@ -37,7 +37,7 @@ contract SmartIdentity {
      */
     modifier onlyBy(address _account) {
         if (msg.sender != _account) {
-            throw;
+            revert();
         }
         _;
     }
@@ -50,7 +50,7 @@ contract SmartIdentity {
      */
     modifier checkBlockLock() {
         if (blocklock + BLOCK_HEIGHT > block.number) {
-            throw;
+            revert();
         }
         _;
     }
@@ -155,7 +155,7 @@ contract SmartIdentity {
         var attribute = attributes[_hash];
         if (attribute.hash == _hash) {
             sendEvent(SIG_CHANGE_EVENT, "A hash exists for the attribute");
-            throw;
+            revert();
         }
         attribute.hash = _hash;
         sendEvent(INFO_EVENT, "Attribute has been added");
@@ -183,7 +183,7 @@ contract SmartIdentity {
         var attribute = attributes[_hash];
         if (attribute.hash != _hash) {
             sendEvent(WARNING_EVENT, "Hash not found for attribute");
-            throw;
+            revert();
         }
         delete attributes[_hash];
         sendEvent(SIG_CHANGE_EVENT, "Attribute has been removed");
@@ -198,12 +198,12 @@ contract SmartIdentity {
         var attribute = attributes[_attributeHash];
         if (attribute.hash != _attributeHash) {
             sendEvent(ERROR_EVENT, "Attribute doesn't exist");
-            throw;
+            revert();
         }
         var endorsement = attribute.endorsements[_endorsementHash];
         if (endorsement.hash == _endorsementHash) {
             sendEvent(ERROR_EVENT, "Endorsement already exists");
-            throw;
+            revert();
         }
         endorsement.hash = _endorsementHash;
         endorsement.endorser = msg.sender;
@@ -262,7 +262,7 @@ contract SmartIdentity {
             return true;
         }
         sendEvent(SIG_CHANGE_EVENT, "Endorsement removal failed");
-        throw;
+        revert();
     }
 
     /**

--- a/contracts/SmartIdentityRegistry.sol
+++ b/contracts/SmartIdentityRegistry.sol
@@ -42,9 +42,9 @@ contract SmartIdentityRegistry {
      */
     modifier onlyBy(address _account) {
         if (msg.sender != _account) {
-            throw;
-            _;
+            revert();
         }
+        _;
     }
 
     /**
@@ -90,7 +90,7 @@ contract SmartIdentityRegistry {
                 }
             }
         } else {
-            throw;
+            revert();
         }
     }
 
@@ -109,7 +109,7 @@ contract SmartIdentityRegistry {
             return true;
         }
         if (sicontracts[_contractHash].status == REJECTED) {
-            throw;
+            revert();
         } else {
             return false;
         }
@@ -136,7 +136,7 @@ contract SmartIdentityRegistry {
     /**
      * modifier checkIdentity(address identity, address registry) return (bool) {
      *  if ( registry.isValidContract(identity) != 1 ) {
-     *    throw;
+     *    revert();
      *    _;
      *  }
      * }


### PR DESCRIPTION
I believe revert() is the right method to use based on the documentation:  http://solidity.readthedocs.io/en/develop/units-and-global-variables.html

As all tests still pass, and our 'throw' functions would historically have blocked any state change for the contracts.  There may be a better solution, or an option to improve the contract logic using these new methods, but this can be done in future.  All tests are currently still passing.